### PR TITLE
Add Generation Test

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -22,4 +22,6 @@ jobs:
     - name: Pylint
       run: pylint unikorn_openstack_policy
     - name: Unit Test
-      run: python -m unittest unikorn_openstack_policy/policy_test.py
+      run: python -m unittest discover
+    - name: Test Generation
+      run: oslopolicy-policy-generator --namespace unikorn_openstack_policy

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pip3 install dist/python_unikorn_openstack_policy-0.1.0-py3-none-any.whl
 ## Generating Policy Files
 
 ```bash
-oslopolicy-sample-generator --namespace unikorn_openstack_policy
+oslopolicy-policy-generator --namespace unikorn_openstack_policy
 ```
 
 ## Coding Standards
@@ -30,4 +30,12 @@ You require 10/10 when running:
 
 ```bash
 pylint unikorn_openstack_policy
+```
+
+## Testing
+
+You must test everything works and get 100% pass rate when running:
+
+```bash
+python3 -m unittest discover
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ dependencies = [
 homepage = "https://github.com/unikorn-cloud/python-unikorn-openstack-policy"
 
 [project.entry-points."oslo.policy.policies"]
-unikorn_openstack_policy = "unikorn_openstack_policy.policy:list_rules"
+unikorn_openstack_policy = "unikorn_openstack_policy:list_rules"
+
+[project.entry-points."oslo.policy.enforcer"]
+unikorn_openstack_policy = "unikorn_openstack_policy:get_enforcer"
 
 # vi: ts=4 noet:

--- a/unikorn_openstack_policy/network.py
+++ b/unikorn_openstack_policy/network.py
@@ -30,38 +30,46 @@ rules = [
         description='Rule for manager access',
     ),
 
+    # A common helper to define that the user is a manager and the resource
+    # target is in the same domain as the user is scoped to.
+    policy.RuleDefault(
+        name='is_domain_manager_owner',
+        check_str='rule:is_domain_manager and domain_id:%(domain_id)s',
+        description='Rule for domain manager ownership',
+    ),
+
     # The domain manager can create and delete networks in its domain.
     # If the domain manager is able to create a network, it can also create provider networks.
     # Don't be naive enough here to assume the ability to provision a network is enough to
     # allow provider networks, if the prior rule changes, then we can open up a security hole.
     policy.RuleDefault(
         name='create_network',
-        check_str='(rule:is_domain_manager and domain_id:%(domain_id)s) or rule:base_create_network',
+        check_str='rule:is_domain_manager_owner or rule:base_create_network',
         description='Create a network',
     ),
     policy.RuleDefault(
         name='delete_network',
-        check_str='(rule:is_domain_manager and domain_id:%(domain_id)s) or rule:base_delete_network',
+        check_str='rule:is_domain_manager_owner or rule:base_delete_network',
         description='Delete a network',
     ),
     policy.RuleDefault(
         name='create_network:segments',
-        check_str='(rule:is_domain_manager and domain_id:%(domain_id)s) or rule:base_create_network:segments',
+        check_str='rule:is_domain_manager_owner or rule:base_create_network:segments',
         description='Specify ``segments`` attribute when creating a network',
     ),
     policy.RuleDefault(
         name='create_network:provider:network_type',
-        check_str='(rule:is_domain_manager and domain_id:%(domain_id)s) or rule:base_create_network:provider:physical_network',
+        check_str='rule:is_domain_manager_owner or rule:base_create_network:provider:physical_network',
         description='Specify ``provider:network_type`` when creating a network',
     ),
     policy.RuleDefault(
         name='create_network:provider:physical_network',
-        check_str='(rule:is_domain_manager and domain_id:%(domain_id)s) or rule:base_create_network:provider:network_type',
+        check_str='rule:is_domain_manager_owner or rule:base_create_network:provider:network_type',
         description='Specify ``provider:physical_network`` when creating a network',
     ),
     policy.RuleDefault(
         name='create_network:provider:segmentation_id',
-        check_str='(rule:is_domain_manager and domain_id:%(domain_id)s) or rule:base_create_network:provider:segmentation_id',
+        check_str='rule:is_domain_manager_owner or rule:base_create_network:provider:segmentation_id',
         description='Specify ``provider:segmentation_id`` when creating a network',
     ),
 ]

--- a/unikorn_openstack_policy/tests/__init__.py
+++ b/unikorn_openstack_policy/tests/__init__.py
@@ -12,31 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Base library entrypoints.
-"""
-
-import itertools
-
-from oslo_config import cfg
-from oslo_policy import policy
-
-from unikorn_openstack_policy import network
-
-def list_rules():
-    """Implements the "oslo.policy.policies" entry point"""
-
-    return itertools.chain(
-        network.list_rules(),
-    )
-
-
-def get_enforcer():
-    """Implements the "oslo.policy.enforcer" entry point"""
-
-    enforcer = policy.Enforcer(conf=cfg.CONF)
-    enforcer.register_defaults(list_rules())
-
-    return enforcer
-
 # vi: ts=4 et:

--- a/unikorn_openstack_policy/tests/test_network.py
+++ b/unikorn_openstack_policy/tests/test_network.py
@@ -1,8 +1,21 @@
+# Copyright 2024 the Unikorn Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """
 Unit tests for OpenStack policies.
 """
 
-import tempfile
 import unittest
 import uuid
 
@@ -10,7 +23,7 @@ from oslo_policy import policy
 from oslo_config import cfg
 from oslo_context.context import RequestContext
 
-from unikorn_openstack_policy.policy import list_rules
+from unikorn_openstack_policy import get_enforcer
 
 class NetworkPolicyTestsBase(unittest.TestCase):
     """
@@ -48,19 +61,8 @@ class NetworkPolicyTestsBase(unittest.TestCase):
         # Setup the configuration, which is required for policy file loading...
         cfg.CONF(args=[])
 
-        # ... which cannot be ignored.
-        with tempfile.NamedTemporaryFile() as policy_file:
-            enforcer = policy.Enforcer(conf=cfg.CONF, policy_file=policy_file.name)
-
-            # Add our default rules to the enforcer, so they get loaded
-            enforcer.register_defaults(list_rules())
-            enforcer.load_rules()
-
-            # Then disable re-reading as the file is about to disappear and the
-            # rules are reloaded on every invocation.
-            enforcer.use_conf = False
-
-            self.enforcer = enforcer
+        self.enforcer = get_enforcer()
+        self.enforcer.load_rules()
 
         # Set up share helper objects.
         self.domain_id = uuid.uuid4().hex
@@ -398,3 +400,5 @@ class DomainMemberNeworkPolicyTests(NetworkPolicyTestsBase):
                 policy.PolicyNotAuthorized,
                 self.enforce,
                 'delete_network', self.target, self.context)
+
+# vi: ts=4 et:


### PR DESCRIPTION
Reorganize everything so tests are separate and policies are in separate context specific files.  Add top level entry points and add in an enforcer entry point to allow generation of policy files.