### PR TITLE
Fuck OpenStack

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,57 @@
 
 Oslo policy generation and testing framework.
 
-## Installation
+### Network Service
+
+We need the following to be allowed (non-root):
+
+* Provisioning of provider networks in managed projects
+
+Problem with Neutron is, it has zero view of identity hierarchies.
+When you create a network, for example, it infers the network from the token, and that's it.
+There is no way to infer the domain also and allow access at that level.
+This may, in fact, although not proven, go all the way back to Keystone not encoding this hierarchical information in the token.
+Which then, basically, says that Keystone's encoding of scope in a token is totally stupid in the first place, and should be way more generalized, because having to re-authenticate in multiple scopes is a massive butt pain.
+
+Then, after you consider the lack of decent support for scoped policies, there is the fact that provisioning with a specific project ID is not even handled by policies at all, but hard coded, then we are in a world of pain.
+
+Our only remaining option is to take our domain admin `manager` role, and create a role on every project we create.
+Then when we want to create a network, we need to create a token bound to that project.
+Finally, we need to allow the `manager` to create provider networks in the project.
+
+## Usage
+
+You first need to create a non-admin role to perform all the necessary actions.
+Unikorn already requires the [SCS domain admin](https://docs.scs.community/standards/scs-0302-v1-domain-manager-role/) functionality for reduced privilege user/project creation, so we use the same role.
+As an admin account:
+
+```bash
+openstack role create manager
+```
+
+Assuming a user has then been created, with the `manager` role on a domain, authenticate as that user scoped to the managed domain, then create a project/user:
+
+```bash
+openstack project create --domain my-managed-domain my-project
+openstack user create --domain my-managed-domain my-user
+```
+
+Then to actually provision a provider network you need to bind the `manager` role to the project:
+
+```bash
+openstack role add --user my-manager-user --domain my-managed-domain --project my-project manager
+```
+
+At this point, you must have [installed](#installation) the policies we define in this library, though whatever mechanism your orchestration layer provides.
+Re-authenticate as the `manager` user, now scoped to the project, and create the network:
+
+```bash
+openstack network create --provider-network-type vlan --provider-physical-network physnet1 --provider-segment 666 my-provider-network
+```
+
+Then, after all that, take a step back and assess your life choices and whether you should be using OpenStack in the first place...
+
+### Installation
 
 > [!NOTE]
 > Running the following will install all the necessary dependencies.
@@ -18,13 +68,15 @@ python3 -m build
 pip3 install dist/python_unikorn_openstack_policy-0.1.0-py3-none-any.whl
 ```
 
-## Generating Policy Files
+### Generating Policy Files
 
 ```bash
 oslopolicy-policy-generator --namespace unikorn_openstack_policy
 ```
 
-## Coding Standards
+## Development
+
+### Coding Standards
 
 You require 10/10 when running:
 
@@ -32,7 +84,7 @@ You require 10/10 when running:
 pylint unikorn_openstack_policy
 ```
 
-## Testing
+### Testing
 
 You must test everything works and get 100% pass rate when running:
 

--- a/unikorn_openstack_policy/tests/test_network.py
+++ b/unikorn_openstack_policy/tests/test_network.py
@@ -19,6 +19,7 @@ Unit tests for OpenStack policies.
 import unittest
 import uuid
 
+from neutron.conf.policies import base
 from oslo_policy import policy
 from oslo_config import cfg
 from oslo_context.context import RequestContext
@@ -61,7 +62,11 @@ class NetworkPolicyTestsBase(unittest.TestCase):
         # Setup the configuration, which is required for policy file loading...
         cfg.CONF(args=[])
 
+        # We only expose our rules and rules we've directly inherited in the
+        # enforcer defaults, so we need to add any base rules neutrok defines
+        # that the inherited rules also refer to.
         self.enforcer = get_enforcer()
+        self.enforcer.register_defaults(base.list_rules())
         self.enforcer.load_rules()
 
         # Set up share helper objects.
@@ -190,46 +195,55 @@ class ProjectManagerNetworkPolicyTests(NetworkPolicyTestsBase):
         self.context = self.project_manager_context
 
     def test_create_network(self):
-        """Project manager cannot create networks"""
+        """Project manager can create networks in its domain"""
+        self.assertTrue(self.enforce('create_network', self.target, self.context))
         self.assertRaises(
                 policy.PolicyNotAuthorized,
                 self.enforce,
-                'create_network', self.target, self.context)
+                'create_network', self.alt_target, self.context)
 
     def test_create_network_segments(self):
-        """Project manager cannot specify network segments"""
+        """Project manager can specifiy network segments"""
+        self.assertTrue(self.enforce('create_network:segments', self.target, self.context))
         self.assertRaises(
                 policy.PolicyNotAuthorized,
                 self.enforce,
-                'create_network:segments', self.target, self.context)
+                'create_network:segments', self.alt_target, self.context)
 
     def test_create_network_provider_network_type(self):
-        """Project manager cannot specify provider network types"""
+        """Project manager can specify provider network types"""
+        self.assertTrue(
+                self.enforce('create_network:provider:network_type', self.target, self.context))
         self.assertRaises(
                 policy.PolicyNotAuthorized,
                 self.enforce,
-                'create_network:provider:network_type', self.target, self.context)
+                'create_network:provider:network_type', self.alt_target, self.context)
 
     def test_create_network_provider_physical_network(self):
-        """Project manager cannot specify provider phyical networks"""
+        """Project manager can specify provider phyical networks"""
+        self.assertTrue(
+                self.enforce('create_network:provider:physical_network', self.target, self.context))
         self.assertRaises(
                 policy.PolicyNotAuthorized,
                 self.enforce,
-                'create_network:provider:physical_network', self.target, self.context)
+                'create_network:provider:physical_network', self.alt_target, self.context)
 
     def test_create_network_provider_segmentation_id(self):
-        """Project manager cannot specify provider segmentation IDs"""
+        """Project manager can specify provider segmentation IDs"""
+        self.assertTrue(
+                self.enforce('create_network:provider:segmentation_id', self.target, self.context))
         self.assertRaises(
                 policy.PolicyNotAuthorized,
                 self.enforce,
-                'create_network:provider:segmentation_id', self.target, self.context)
+                'create_network:provider:segmentation_id', self.alt_target, self.context)
 
     def test_delete_network(self):
-        """Project manager cannot delete networks"""
+        """Project manager cannot create networks"""
+        self.assertTrue(self.enforce('delete_network', self.target, self.context))
         self.assertRaises(
                 policy.PolicyNotAuthorized,
                 self.enforce,
-                'delete_network', self.target, self.context)
+                'delete_network', self.alt_target, self.context)
 
 
 class DomainManagerNeworkPolicyTests(NetworkPolicyTestsBase):
@@ -243,51 +257,67 @@ class DomainManagerNeworkPolicyTests(NetworkPolicyTestsBase):
         self.context = self.domain_manager_context
 
     def test_create_network(self):
-        """Domain manager can create networks in its domain"""
-        self.assertTrue(self.enforce('create_network', self.target, self.context))
+        """Domain manager cannot create networks"""
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                'create_network', self.target, self.context)
         self.assertRaises(
                 policy.PolicyNotAuthorized,
                 self.enforce,
                 'create_network', self.alt_target, self.context)
 
     def test_create_network_segments(self):
-        """Domain manager can specifiy network segments"""
-        self.assertTrue(self.enforce('create_network:segments', self.target, self.context))
+        """Domain manager cannot specify network segments"""
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                'create_network:segments', self.target, self.context)
         self.assertRaises(
                 policy.PolicyNotAuthorized,
                 self.enforce,
                 'create_network:segments', self.alt_target, self.context)
 
     def test_create_network_provider_network_type(self):
-        """Domain manager can specify provider network types"""
-        self.assertTrue(
-                self.enforce('create_network:provider:network_type', self.target, self.context))
+        """Domain manager cannot specify provider network types"""
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                'create_network:provider:network_type', self.target, self.context)
         self.assertRaises(
                 policy.PolicyNotAuthorized,
                 self.enforce,
                 'create_network:provider:network_type', self.alt_target, self.context)
 
     def test_create_network_provider_physical_network(self):
-        """Domain manager can specify provider phyical networks"""
-        self.assertTrue(
-                self.enforce('create_network:provider:physical_network', self.target, self.context))
+        """Domain manager cannot specify provider phyical networks"""
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                'create_network:provider:physical_network', self.target, self.context)
         self.assertRaises(
                 policy.PolicyNotAuthorized,
                 self.enforce,
                 'create_network:provider:physical_network', self.alt_target, self.context)
 
     def test_create_network_provider_segmentation_id(self):
-        """Domain manager can specify provider segmentation IDs"""
-        self.assertTrue(
-                self.enforce('create_network:provider:segmentation_id', self.target, self.context))
+        """Domain manager cannot specify provider segmentation IDs"""
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                'create_network:provider:segmentation_id', self.target, self.context)
         self.assertRaises(
                 policy.PolicyNotAuthorized,
                 self.enforce,
                 'create_network:provider:segmentation_id', self.alt_target, self.context)
 
+
     def test_delete_network(self):
-        """Domain manager cannot create networks"""
-        self.assertTrue(self.enforce('delete_network', self.target, self.context))
+        """Domain manager cannot delete networks"""
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                'delete_network', self.target, self.context)
         self.assertRaises(
                 policy.PolicyNotAuthorized,
                 self.enforce,


### PR DESCRIPTION
Add in support to grab existing rules from the OpenStack distro, then essentially reduce them into one liners so we can override the existing policies.  Then, because OpenStack is essentially bollocks, we need to work around its inadequacies to make it even work, because half the infromation required is missing, and a lot of what would be required is actually hard coded to fail.