### PR TITLE
Add Block Storage Quotas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /dist
+/venv
 /python_unikorn_openstack_policy.egg-info/
 __pycache__
 *.swp

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ We need the following to be allowed (non-root):
 * Management of quotas
 * Provisioning of provider networks in managed projects
 
+### Block Storage Service
+
+We need the following to be allowed (non-root):
+
+* Management of quotas
+
 ### Design
 
 Problem with any service that isn't Keystone is, it has zero view of identity hierarchies.
@@ -78,18 +84,25 @@ openstack network create --provider-network-type vlan --provider-physical-networ
 
 ### Installation
 
+```bash
+python3 -m venv venv
+source venv/bin/activate
+pip3 install build pylint
+```
+
 > [!NOTE]
 > Running the following will install all the necessary dependencies.
 > This also includes any commands required for the the following sections.
 
 ```bash
 python3 -m build
-pip3 install dist/python_unikorn_openstack_policy-0.1.0-py3-none-any.whl
+pip3 install --force-reinstall dist/python_unikorn_openstack_policy-0.1.0-py3-none-any.whl
 ```
 
 ### Generating Policy Files
 
 ```bash
+oslopolicy-policy-generator --namespace unikorn_openstack_policy_blockstorage
 oslopolicy-policy-generator --namespace unikorn_openstack_policy_compute
 oslopolicy-policy-generator --namespace unikorn_openstack_policy_network
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,19 +24,22 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [
-	"oslo.config",
+	"cinder",
 	"neutron",
-	"nova"
+	"nova",
+	"oslo.config",
 ]
 
 [project.urls]
 homepage = "https://github.com/unikorn-cloud/python-unikorn-openstack-policy"
 
 [project.entry-points."oslo.policy.policies"]
+unikorn_openstack_policy_blockstorage = "unikorn_openstack_policy.blockstorage:list_rules"
 unikorn_openstack_policy_compute = "unikorn_openstack_policy.compute:list_rules"
 unikorn_openstack_policy_network = "unikorn_openstack_policy.network:list_rules"
 
 [project.entry-points."oslo.policy.enforcer"]
+unikorn_openstack_policy_blockstorage = "unikorn_openstack_policy.blockstorage:get_enforcer"
 unikorn_openstack_policy_compute = "unikorn_openstack_policy.compute:get_enforcer"
 unikorn_openstack_policy_network = "unikorn_openstack_policy.network:get_enforcer"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-neutron>=24.0.1
-oslo.policy>=4.4.0

--- a/unikorn_openstack_policy/blockstorage.py
+++ b/unikorn_openstack_policy/blockstorage.py
@@ -18,7 +18,8 @@ Defines Oslo Policy Rules.
 
 # pylint: disable=line-too-long
 
-from nova import policies
+from cinder import policies
+from cinder.policies import quotas
 from oslo_config import cfg
 from oslo_policy import policy
 from unikorn_openstack_policy import base
@@ -27,9 +28,9 @@ rules = [
     # The domain manager needs to be able to alter the default quotas
     # or it won't we able to fulfill any cluster creation requests.
     policy.RuleDefault(
-        name='os_compute_api:os-quota-sets:update',
+        name=quotas.UPDATE_POLICY,
         check_str='rule:is_project_manager',
-        description='Update the compute quotas',
+        description='Update the block storage quotas',
     )
 ]
 

--- a/unikorn_openstack_policy/tests/test_blockstorage.py
+++ b/unikorn_openstack_policy/tests/test_blockstorage.py
@@ -1,0 +1,134 @@
+# Copyright 2024 the Unikorn Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for OpenStack policies.
+"""
+
+from cinder.policies import quotas
+from oslo_policy import policy
+
+from unikorn_openstack_policy import blockstorage
+from unikorn_openstack_policy.tests import base
+
+class ProjectAdminBlockStoragePolicyTests(base.PolicyTestsBase):
+    """
+    Checks policy enforcement for project scoped admin role.
+    """
+
+    # Request context.
+    context = None
+
+    def setUp(self):
+        """Perform setup actions for all tests"""
+        self.setup(blockstorage.get_enforcer())
+        self.context = self.project_admin_context
+
+    def test_update_quota_sets(self):
+        """Admin can update quota sets"""
+        self.assertTrue(self.enforce(
+            quotas.UPDATE_POLICY, self.target, self.context))
+
+
+class DomainAdminBlockStoragePolicyTests(ProjectAdminBlockStoragePolicyTests):
+    """
+    Checks policy enforcement for domain scoped admin role
+    """
+
+    def setUp(self):
+        self.setup(blockstorage.get_enforcer())
+        self.context = self.domain_admin_context
+
+
+class ProjectManagerBlockStoragePolicyTests(base.PolicyTestsBase):
+    """
+    Checks policy enforcement for project scoped manager role
+    """
+
+    # Request context.
+    context = None
+
+    def setUp(self):
+        """Perform setup actions for all tests"""
+        self.setup(blockstorage.get_enforcer())
+        self.context = self.project_manager_context
+
+    def test_update_quota_sets(self):
+        """Project manager can update quota sets"""
+        self.assertTrue(self.enforce(
+            quotas.UPDATE_POLICY, self.target, self.context))
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                quotas.UPDATE_POLICY, self.alt_target, self.context)
+
+
+class DomainManagerBlockStoragePolicyTests(base.PolicyTestsBase):
+    """
+    Checks policy enforcement for the manager role.
+    """
+
+    def setUp(self):
+        """Perform setup actions for all tests"""
+        self.setup(blockstorage.get_enforcer())
+        self.context = self.domain_manager_context
+
+    def test_update_quota_sets(self):
+        """Domain manager cannot update quota sets"""
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                quotas.UPDATE_POLICY, self.target, self.context)
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                quotas.UPDATE_POLICY, self.alt_target, self.context)
+
+
+class ProjectMemberBlockStoragePolicyTests(base.PolicyTestsBase):
+    """
+    Checks policy enforcement for the member role.
+    """
+
+    def setUp(self):
+        """Perform setup actions for all tests"""
+        self.setup(blockstorage.get_enforcer())
+        self.context = self.project_member_context
+
+    def test_update_quota_sets(self):
+        """Project member cannot create quota sets"""
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                quotas.UPDATE_POLICY, self.target, self.context)
+
+
+class DomainMemberBlockStoragePolicyTests(base.PolicyTestsBase):
+    """
+    Checks policy enforcement for the member role.
+    """
+
+    def setUp(self):
+        """Perform setup actions for all tests"""
+        self.setup(blockstorage.get_enforcer())
+        self.context = self.domain_member_context
+
+    def test_update_quota_sets(self):
+        """Domain member cannot create quota sets"""
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                quotas.UPDATE_POLICY, self.target, self.context)
+
+# vi: ts=4 et:


### PR DESCRIPTION
Like compute before it, we need to tweak quotas to allow services to provision sane amounts.  These are typically set at a paltry 100 volumes and 1TB.