### PR TITLE
Grant the project_manager `publicize_image`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ We need the following to be allowed (non-root):
 
 * Management of quotas
 
+### Image Service (Glance)
+
+We need the following to be allowed (non-root):
+
+* Publicize image
+
 ### Design
 
 Problem with any service that isn't Keystone is, it has zero view of identity hierarchies.
@@ -102,6 +108,7 @@ pip3 install --force-reinstall --no-deps dist/python_unikorn_openstack_policy-0.
 oslopolicy-policy-generator --namespace unikorn_openstack_policy_blockstorage
 oslopolicy-policy-generator --namespace unikorn_openstack_policy_compute
 oslopolicy-policy-generator --namespace unikorn_openstack_policy_network
+oslopolicy-policy-generator --namespace unikorn_openstack_policy_image
 ```
 
 ## Development

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
 	"cinder ~= 25.0",
 	"neutron ~= 25.0",
 	"nova ~= 30.0",
+    "glance ~= 29.0",
 	"oslo.config ~= 9.5.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,12 @@ homepage = "https://github.com/unikorn-cloud/python-unikorn-openstack-policy"
 unikorn_openstack_policy_blockstorage = "unikorn_openstack_policy.blockstorage:list_rules"
 unikorn_openstack_policy_compute = "unikorn_openstack_policy.compute:list_rules"
 unikorn_openstack_policy_network = "unikorn_openstack_policy.network:list_rules"
+unikorn_openstack_policy_image = "unikorn_openstack_policy.image:list_rules"
 
 [project.entry-points."oslo.policy.enforcer"]
 unikorn_openstack_policy_blockstorage = "unikorn_openstack_policy.blockstorage:get_enforcer"
 unikorn_openstack_policy_compute = "unikorn_openstack_policy.compute:get_enforcer"
 unikorn_openstack_policy_network = "unikorn_openstack_policy.network:get_enforcer"
+unikorn_openstack_policy_image = "unikorn_openstack_policy.image:get_enforcer"
 
 # vi: ts=4 noet:

--- a/unikorn_openstack_policy/image.py
+++ b/unikorn_openstack_policy/image.py
@@ -1,0 +1,53 @@
+# Copyright 2024 the Unikorn Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Defines Oslo Policy Rules for image operations.
+"""
+
+# Here's the reference for Glance permissions:
+# https://docs.openstack.org/ocata/config-reference/image/policy.json.html
+
+from glance import policies
+from oslo_config import cfg
+from oslo_policy import policy
+from unikorn_openstack_policy import base
+
+PUBLICIZE = 'publicize_image'
+
+rules = [
+    # The domain manager needs to be able to publicize images, because
+    # snapshots are private by default and we need them accessible across projects.
+    policy.RuleDefault(
+        name=PUBLICIZE,
+        check_str='rule:is_project_manager',
+        description="Make an image's visibility public",
+    )
+]
+
+# pylint: disable=R0801
+def list_rules():
+    """Implements the "oslo.policy.policies" entry point"""
+    return base.inherit_rules(rules, list(policies.list_rules()))
+
+def get_enforcer():
+    """Implements the "oslo.policy.enforcer" entry point"""
+
+    conf=cfg.CONF
+    conf(args=[])
+
+    enforcer = policy.Enforcer(conf=conf)
+    enforcer.register_defaults(list_rules())
+
+    return enforcer

--- a/unikorn_openstack_policy/image.py
+++ b/unikorn_openstack_policy/image.py
@@ -31,7 +31,7 @@ rules = [
     # snapshots are private by default and we need them accessible across projects.
     policy.RuleDefault(
         name=PUBLICIZE,
-        check_str='rule:is_project_manager',
+        check_str='role:image-publisher or rule:is_project_manager',
         description="Make an image's visibility public",
     )
 ]

--- a/unikorn_openstack_policy/tests/test_image.py
+++ b/unikorn_openstack_policy/tests/test_image.py
@@ -1,0 +1,133 @@
+# Copyright 2024 the Unikorn Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Unit tests for OpenStack policies.
+"""
+
+from oslo_policy import policy
+
+from unikorn_openstack_policy import image
+from unikorn_openstack_policy.tests import base
+
+class ProjectAdminImagePolicyTests(base.PolicyTestsBase):
+    """
+    Checks policy enforcement for project scoped admin role.
+    """
+
+    # Request context.
+    context = None
+
+    def setUp(self):
+        """Perform setup actions for all tests"""
+        self.setup(image.get_enforcer())
+        self.context = self.project_admin_context
+
+    def test_publicize_image(self):
+        """Admin can publicize an image"""
+        self.assertTrue(self.enforce(
+            image.PUBLICIZE, self.target, self.context))
+
+
+class DomainAdminImagePolicyTests(ProjectAdminImagePolicyTests):
+    """
+    Checks policy enforcement for domain scoped admin role
+    """
+
+    def setUp(self):
+        self.setup(image.get_enforcer())
+        self.context = self.domain_admin_context
+
+
+class ProjectManagerImagePolicyTests(base.PolicyTestsBase):
+    """
+    Checks policy enforcement for project scoped manager role
+    """
+
+    # Request context.
+    context = None
+
+    def setUp(self):
+        """Perform setup actions for all tests"""
+        self.setup(image.get_enforcer())
+        self.context = self.project_manager_context
+
+    def test_publicize_image(self):
+        """Project manager can publicize image"""
+        self.assertTrue(self.enforce(
+            image.PUBLICIZE, self.target, self.context))
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                image.PUBLICIZE, self.alt_target, self.context)
+
+
+class DomainManagerImagePolicyTests(base.PolicyTestsBase):
+    """
+    Checks policy enforcement for the manager role.
+    """
+
+    def setUp(self):
+        """Perform setup actions for all tests"""
+        self.setup(image.get_enforcer())
+        self.context = self.domain_manager_context
+
+    def test_publicize_image(self):
+        """Domain manager cannot publicize image"""
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                image.PUBLICIZE, self.target, self.context)
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                image.PUBLICIZE, self.alt_target, self.context)
+
+
+class ProjectMemberImagePolicyTests(base.PolicyTestsBase):
+    """
+    Checks policy enforcement for the project member role.
+    """
+
+    def setUp(self):
+        """Perform setup actions for all tests"""
+        self.setup(image.get_enforcer())
+        self.context = self.project_member_context
+
+    def test_publicize_image(self):
+        """Project member cannot publicize image"""
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                image.PUBLICIZE, self.target, self.context)
+
+
+class DomainMemberImagePolicyTests(base.PolicyTestsBase):
+    """
+    Checks policy enforcement for the domain member role.
+    """
+
+    def setUp(self):
+        """Perform setup actions for all tests"""
+        self.setup(image.get_enforcer())
+        self.context = self.domain_member_context
+
+    def test_publicize_image(self):
+        """Domain member cannot publicize image"""
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                image.PUBLICIZE, self.target, self.context)
+
+# vi: ts=4 et:


### PR DESCRIPTION
To be able to save server snapshots and make them available to UNI users*, the service accounts used for UNI need to have publicize_image. Here I've simply followed what compute.py does, using the same predicate (`is_project_manager`) and the permission `publicize_image` as mentioned in

    https://docs.openstack.org/glance/latest/_modules/glance/policies/image.html

*Snapshots are created private, and can only become available across UNI projects by being made public.

From https://docs.openstack.org/ocata/config-reference/image/policy.json.html I gather than it's only publicize_image that's restricted to admin (and needs to be changed here).