### PR TITLE
Allow managers to request host placement

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Oslo policy generation and testing framework.
 We need the following to be allowed (non-root):
 
 * Management of quotas
+* Requesting server placement on specific compute hosts
 
 ### Network Service
 

--- a/unikorn_openstack_policy/compute.py
+++ b/unikorn_openstack_policy/compute.py
@@ -23,11 +23,22 @@ from oslo_config import cfg
 from oslo_policy import policy
 from unikorn_openstack_policy import base
 
+SERVER_CREATE_REQUESTED_DESTINATION = 'compute:servers:create:requested_destination'
+QUOTA_UPDATE = 'os_compute_api:os-quota-sets:update'
+
 rules = [
+    # Allow project managers to request host/hypervisor_hostname placement
+    # while still having Nova run the scheduler filters.
+    policy.RuleDefault(
+        name=SERVER_CREATE_REQUESTED_DESTINATION,
+        check_str='rule:is_project_manager',
+        description='Create a server on a requested compute host',
+    ),
+
     # The domain manager needs to be able to alter the default quotas
     # or it won't we able to fulfill any cluster creation requests.
     policy.RuleDefault(
-        name='os_compute_api:os-quota-sets:update',
+        name=QUOTA_UPDATE,
         check_str='rule:is_project_manager',
         description='Update the compute quotas',
     )

--- a/unikorn_openstack_policy/compute.py
+++ b/unikorn_openstack_policy/compute.py
@@ -24,6 +24,7 @@ from oslo_policy import policy
 from unikorn_openstack_policy import base
 
 SERVER_CREATE_REQUESTED_DESTINATION = 'compute:servers:create:requested_destination'
+SERVER_CREATE_FORCED_HOST = 'os_compute_api:servers:create:forced_host'
 QUOTA_UPDATE = 'os_compute_api:os-quota-sets:update'
 
 rules = [
@@ -33,6 +34,11 @@ rules = [
         name=SERVER_CREATE_REQUESTED_DESTINATION,
         check_str='rule:is_project_manager',
         description='Create a server on a requested compute host',
+    ),
+    policy.RuleDefault(
+        name=SERVER_CREATE_FORCED_HOST,
+        check_str='rule:is_project_manager',
+        description='Create a server on a forced compute host',
     ),
 
     # The domain manager needs to be able to alter the default quotas

--- a/unikorn_openstack_policy/tests/test_compute.py
+++ b/unikorn_openstack_policy/tests/test_compute.py
@@ -37,7 +37,14 @@ class ProjectAdminComputePolicyTests(base.PolicyTestsBase):
     def test_update_quota_sets(self):
         """Admin can update quota sets"""
         self.assertTrue(self.enforce(
-            'os_compute_api:os-quota-sets:update', self.target, self.context))
+            compute.QUOTA_UPDATE, self.target, self.context))
+
+    def test_create_server_requested_destination(self):
+        """Admin can create servers on a requested host"""
+        self.assertTrue(self.enforce(
+            compute.SERVER_CREATE_REQUESTED_DESTINATION, self.target, self.context))
+        self.assertTrue(self.enforce(
+            compute.SERVER_CREATE_REQUESTED_DESTINATION, self.alt_target, self.context))
 
 
 class DomainAdminComputePolicyTests(ProjectAdminComputePolicyTests):
@@ -66,11 +73,20 @@ class ProjectManagerComputePolicyTests(base.PolicyTestsBase):
     def test_update_quota_sets(self):
         """Project manager can update quota sets"""
         self.assertTrue(self.enforce(
-            'os_compute_api:os-quota-sets:update', self.target, self.context))
+            compute.QUOTA_UPDATE, self.target, self.context))
         self.assertRaises(
                 policy.PolicyNotAuthorized,
                 self.enforce,
-                'os_compute_api:os-quota-sets:update', self.alt_target, self.context)
+                compute.QUOTA_UPDATE, self.alt_target, self.context)
+
+    def test_create_server_requested_destination(self):
+        """Project manager can create servers on a requested host"""
+        self.assertTrue(self.enforce(
+            compute.SERVER_CREATE_REQUESTED_DESTINATION, self.target, self.context))
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                compute.SERVER_CREATE_REQUESTED_DESTINATION, self.alt_target, self.context)
 
 
 class DomainManagerComputePolicyTests(base.PolicyTestsBase):
@@ -88,11 +104,22 @@ class DomainManagerComputePolicyTests(base.PolicyTestsBase):
         self.assertRaises(
                 policy.PolicyNotAuthorized,
                 self.enforce,
-                'os_compute_api:os-quota-sets:update', self.target, self.context)
+                compute.QUOTA_UPDATE, self.target, self.context)
         self.assertRaises(
                 policy.PolicyNotAuthorized,
                 self.enforce,
-                'os_compute_api:os-quota-sets:update', self.alt_target, self.context)
+                compute.QUOTA_UPDATE, self.alt_target, self.context)
+
+    def test_create_server_requested_destination(self):
+        """Domain manager cannot create servers on a requested host"""
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                compute.SERVER_CREATE_REQUESTED_DESTINATION, self.target, self.context)
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                compute.SERVER_CREATE_REQUESTED_DESTINATION, self.alt_target, self.context)
 
 
 class ProjectMemberComputePolicyTests(base.PolicyTestsBase):
@@ -110,7 +137,14 @@ class ProjectMemberComputePolicyTests(base.PolicyTestsBase):
         self.assertRaises(
                 policy.PolicyNotAuthorized,
                 self.enforce,
-                'os_compute_api:os-quota-sets:update', self.target, self.context)
+                compute.QUOTA_UPDATE, self.target, self.context)
+
+    def test_create_server_requested_destination(self):
+        """Project member cannot create servers on a requested host"""
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                compute.SERVER_CREATE_REQUESTED_DESTINATION, self.target, self.context)
 
 
 class DomainMemberComputePolicyTests(base.PolicyTestsBase):
@@ -128,6 +162,13 @@ class DomainMemberComputePolicyTests(base.PolicyTestsBase):
         self.assertRaises(
                 policy.PolicyNotAuthorized,
                 self.enforce,
-                'os_compute_api:os-quota-sets:update', self.target, self.context)
+                compute.QUOTA_UPDATE, self.target, self.context)
+
+    def test_create_server_requested_destination(self):
+        """Domain member cannot create servers on a requested host"""
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                compute.SERVER_CREATE_REQUESTED_DESTINATION, self.target, self.context)
 
 # vi: ts=4 et:

--- a/unikorn_openstack_policy/tests/test_compute.py
+++ b/unikorn_openstack_policy/tests/test_compute.py
@@ -46,6 +46,13 @@ class ProjectAdminComputePolicyTests(base.PolicyTestsBase):
         self.assertTrue(self.enforce(
             compute.SERVER_CREATE_REQUESTED_DESTINATION, self.alt_target, self.context))
 
+    def test_create_server_forced_host(self):
+        """Admin can create servers on a forced host"""
+        self.assertTrue(self.enforce(
+            compute.SERVER_CREATE_FORCED_HOST, self.target, self.context))
+        self.assertTrue(self.enforce(
+            compute.SERVER_CREATE_FORCED_HOST, self.alt_target, self.context))
+
 
 class DomainAdminComputePolicyTests(ProjectAdminComputePolicyTests):
     """
@@ -88,6 +95,15 @@ class ProjectManagerComputePolicyTests(base.PolicyTestsBase):
                 self.enforce,
                 compute.SERVER_CREATE_REQUESTED_DESTINATION, self.alt_target, self.context)
 
+    def test_create_server_forced_host(self):
+        """Project manager can create servers on a forced host"""
+        self.assertTrue(self.enforce(
+            compute.SERVER_CREATE_FORCED_HOST, self.target, self.context))
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                compute.SERVER_CREATE_FORCED_HOST, self.alt_target, self.context)
+
 
 class DomainManagerComputePolicyTests(base.PolicyTestsBase):
     """
@@ -121,6 +137,17 @@ class DomainManagerComputePolicyTests(base.PolicyTestsBase):
                 self.enforce,
                 compute.SERVER_CREATE_REQUESTED_DESTINATION, self.alt_target, self.context)
 
+    def test_create_server_forced_host(self):
+        """Domain manager cannot create servers on a forced host"""
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                compute.SERVER_CREATE_FORCED_HOST, self.target, self.context)
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                compute.SERVER_CREATE_FORCED_HOST, self.alt_target, self.context)
+
 
 class ProjectMemberComputePolicyTests(base.PolicyTestsBase):
     """
@@ -146,6 +173,13 @@ class ProjectMemberComputePolicyTests(base.PolicyTestsBase):
                 self.enforce,
                 compute.SERVER_CREATE_REQUESTED_DESTINATION, self.target, self.context)
 
+    def test_create_server_forced_host(self):
+        """Project member cannot create servers on a forced host"""
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                compute.SERVER_CREATE_FORCED_HOST, self.target, self.context)
+
 
 class DomainMemberComputePolicyTests(base.PolicyTestsBase):
     """
@@ -170,5 +204,12 @@ class DomainMemberComputePolicyTests(base.PolicyTestsBase):
                 policy.PolicyNotAuthorized,
                 self.enforce,
                 compute.SERVER_CREATE_REQUESTED_DESTINATION, self.target, self.context)
+
+    def test_create_server_forced_host(self):
+        """Domain member cannot create servers on a forced host"""
+        self.assertRaises(
+                policy.PolicyNotAuthorized,
+                self.enforce,
+                compute.SERVER_CREATE_FORCED_HOST, self.target, self.context)
 
 # vi: ts=4 et:


### PR DESCRIPTION
Project managers need to request a specific compute host while still letting Nova run scheduler filters. Nova checks the policy `requested_destination` when a server creation request specifies the host: this is how https://github.com/nscaledev/uni-region/pull/488 gives the UNI region service the ability to boot specific machines.

Ordinary create (also checked by Nova) and start permissions remain covered by Nova defaults.
